### PR TITLE
prestashop: fix extra " in translation

### DIFF
--- a/axelor-prestashop/src/main/resources/i18n/messages_fr.csv
+++ b/axelor-prestashop/src/main/resources/i18n/messages_fr.csv
@@ -10,7 +10,7 @@
 "Batch %s unknown",,,
 "Batches",,,
 "Code",,,
-"Company",",,
+"Company",,,
 "Connection","Connexion",,
 "Connection successful",,,
 "Countries are handled on prestashop","Les pays sont gérées sous PrestaShop",,


### PR DESCRIPTION
Missing quote was corrupting translations in other modules